### PR TITLE
Avoid using <title> within _document.js 's <Head>

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,28 @@
+import App, {Container} from 'next/app'
+import Head from 'next/head'
+import React from 'react'
+
+export default class MyApp extends App {
+  static async getInitialProps ({ Component, ctx }) {
+    let pageProps = {}
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx)
+    }
+
+    return { pageProps }
+  }
+
+  render () {
+    const { Component, pageProps } = this.props
+
+    return (
+      <Container>
+        <Head>
+          <title>Canner ❤️ Firebase demo</title>
+        </Head>
+        <Component {...pageProps} />
+      </Container>
+    )
+  }
+}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -15,7 +15,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>Canner ❤️ Firebase demo</title>
           <meta name="description" content="Canner CMS demo with Firebase" />
           <meta charSet="utf-8"/>
           <link rel="stylesheet" href="//cdn.quilljs.com/1.2.6/quill.snow.css"/>


### PR DESCRIPTION
```bash
Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title
```

The Next.js maintainer suggests to only put ```<title>``` element in ```_app.js```.
Also, It's more flexible to change title content in different pages or stages.

Ref:
https://github.com/zeit/next.js/issues/4596
https://github.com/zeit/next.js/blob/master/errors/no-document-title.md